### PR TITLE
Re-enable webhook support as an optional feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,9 @@ You can also install these dependencies via pip (for Python 3) using: `pip3 inst
 
         # Sets whether we should burst Discord guild owners as IRC owners
         show_owner_status: true
+        
+        # Sets whether to use webhooks to show remote user messages as if they were actual Discord users
+        webhooks: false
 
 ```
 


### PR DESCRIPTION
By setting the webhook flag in the server conf, webhooks can be used to improve the output of relayed messages. If the bot does not have permission to create webhooks, or if there's an error during the process of sending the webhook, fall back to regular Clientbot behavior

Fixes #1 