### PR TITLE
Only split off of newline characters for multi-line messages

### DIFF
--- a/protocols/discord.py
+++ b/protocols/discord.py
@@ -440,7 +440,7 @@ class DiscordBotPlugin(Plugin):
                 log.exception('(%s) Error translating from Discord to IRC: %s', self.name, text)
 
             def _send(text):
-                for line in text.splitlines():  # Relay multiline messages as such
+                for line in text.split('\n'):  # Relay multiline messages as such
                     pylink_netobj.call_hooks([message.author.id, 'PRIVMSG', {'target': target, 'text': line}])
 
             _send(text)

--- a/protocols/discord.py
+++ b/protocols/discord.py
@@ -437,7 +437,7 @@ class DiscordBotPlugin(Plugin):
             try:
                 text = D2IFormatter().format(text)
             except:
-                log.exception('(%s) Error translating from Discord to IRC: %s', self.name, message_text)
+                log.exception('(%s) Error translating from Discord to IRC: %s', self.name, text)
 
             def _send(text):
                 for line in text.splitlines():  # Relay multiline messages as such


### PR DESCRIPTION
`text.splitlines` is too liberal for what it considers a line break